### PR TITLE
An alternative approach to rendering the tree which won't trigger the forceUpdate() warning

### DIFF
--- a/app/assets/javascripts/components/comment.es6
+++ b/app/assets/javascripts/components/comment.es6
@@ -43,7 +43,7 @@ class Comment extends React.Component {
 					parent_id={this.props.id}
 					isReplying={this.state.isReplying}
 					onCommentSubmitted={this.onCommentSubmitted.bind(this)} />
-				<CommentList parent_id={this.props.id} />
+				<CommentList comments={this.props.children} parent_id={this.props.id} />
 			</li>
 		);
 	}

--- a/app/assets/javascripts/components/comment_list.es6
+++ b/app/assets/javascripts/components/comment_list.es6
@@ -7,13 +7,18 @@ class CommentList extends React.Component {
 			store: React.PropTypes.object.isRequired
 		}
 	}
-	componentDidMount() {
-		this.context.store.addChangeListener(this._onChange.bind(this));
-	}
-	componentWillUnmount() {
-		this.context.store.removeChangeListener(this._onChange.bind(this));
-	}
+
 	render() {
+		return (
+			<ul>
+		  {this.props.comments.map((comment, i) => {
+		  	return <Comment key={i} {... comment} />;
+		  })}
+		  </ul>
+   );
+  }
+  // this is the render() method that was in the video:
+	legacyRender() {
 		return (
 			<ul>
 		  {this.context.store.comments(this.props.parent_id).map((comment, i) => {
@@ -21,9 +26,6 @@ class CommentList extends React.Component {
 		  })}
 		  </ul>
 		);
-	}
-	_onChange() {
-		this.forceUpdate();
 	}
 }
 export default CommentList

--- a/app/assets/javascripts/components/comment_section.es6
+++ b/app/assets/javascripts/components/comment_section.es6
@@ -22,16 +22,35 @@ class CommentSection extends React.Component {
 			actions: this.actions
 		}
 	}
+	// The warning was caused because the CommentList was being re-ordered and the parent component was effectively
+	// destroying the children while the children had indicated a re-render.
+	// The warning you were seeing wouldn't have appeared in production and it triggered a no-op
+	//
+	// Below is an alternate approach which is closer to a redux-esque pattern of keeping container
+	// components "smart" and anything underneath "dumb". I've transformed the data structure into
+	// a tree in the CommentStore, meaning that each <CommentList> can just pass down their children,
+	// this enables us to listen only at the root node
 	render() {
 		return (
 			<div>
 				<CommentForm isReplying={ true } />
-				<CommentList parent_id={null} />
+				<CommentList comments={this.store.commentsAsTree()} parent_id={null} />
 			</div>
 		)
 	}
 
+  // I've moved the store reference to a root node
+	componentDidMount() {
+		this.store.addChangeListener(this._onChange.bind(this));
+	}
+	componentWillUnmount() {
+		this.store.removeChangeListener(this._onChange.bind(this));
+	}
 
+
+	_onChange() {
+		this.forceUpdate();
+	}
 }
 
 window.CommentSection = CommentSection

--- a/app/assets/javascripts/stores/comment_store.es6
+++ b/app/assets/javascripts/stores/comment_store.es6
@@ -46,6 +46,22 @@ class CommentStore extends EventEmitter {
 						.reverse()
 						.value()
 	}
+
+  commentsAsTree() {
+    var c = this.comments().map((comment) => {
+      return this.attachChildComments(comment)
+    })
+    return c;
+  }
+
+  attachChildComments(comment) {
+    comment.children = (comment.id === null) ? [] : this.comments(comment.id);
+    comment.children.map((childComment) => {
+      return this.attachChildComments(childComment)
+    })
+    return comment;
+  }
+
 	upvote(comment) {
 		this._comments[comment.id].rank++;
 	}

--- a/app/assets/javascripts/stores/comment_store.es6
+++ b/app/assets/javascripts/stores/comment_store.es6
@@ -48,10 +48,9 @@ class CommentStore extends EventEmitter {
 	}
 
   commentsAsTree() {
-    var c = this.comments().map((comment) => {
+    return this.comments().map((comment) => {
       return this.attachChildComments(comment)
     })
-    return c;
   }
 
   attachChildComments(comment) {


### PR DESCRIPTION
Hi Neal,

Thanks again for reaching out to me on Twitter.

The warning was caused because the CommentList was being re-ordered and the parent component was effectively destroying the children while the children had indicated a re-render. The warning you were seeing wouldn't have appeared in production and it triggered a no-op Below is an alternate approach which is closer to a redux-esque pattern of keeping container components "smart" and anything underneath "dumb". I've transformed the data structure into a tree in the CommentStore, meaning that each <CommentList> can just pass down their children, this enables us to listen only at the root node.

Hope this helps!
